### PR TITLE
feat: set higher python-spanner requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import setuptools
 
 name = "sqlalchemy-spanner"
 description = "SQLAlchemy dialect integrated into Cloud Spanner database"
-dependencies = ["sqlalchemy>=1.1.13, <=1.3.23", "google-cloud-spanner>=3.0.0"]
+dependencies = ["sqlalchemy>=1.1.13, <=1.3.23", "google-cloud-spanner>=3.3.0"]
 
 # Only include packages under the 'google' namespace. Do not include tests,
 # benchmarks, etc.


### PR DESCRIPTION
The dialect executes DDL statements separated by `;`. This feature was released in [python-spanner v.3.3.0](https://github.com/googleapis/python-spanner/releases/tag/v3.3.0), so the version of the python-spanner required by the dialect must be at least 3.3.0.