### PR TITLE
test: skip unsupported features tests

### DIFF
--- a/google/cloud/sqlalchemy_spanner/requirements.py
+++ b/google/cloud/sqlalchemy_spanner/requirements.py
@@ -38,6 +38,10 @@ class Requirements(SuiteRequirements):
         return exclusions.open()
 
     @property
+    def implements_get_lastrowid(self):
+        return exclusions.closed()
+
+    @property
     def ctes(self):
         return exclusions.open()
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -58,6 +58,9 @@ from sqlalchemy.testing.suite.test_ddl import (
     LongNameBlowoutTest as _LongNameBlowoutTest,
 )
 from sqlalchemy.testing.suite.test_dialect import EscapingTest as _EscapingTest
+from sqlalchemy.testing.suite.test_insert import (
+    InsertBehaviorTest as _InsertBehaviorTest,
+)
 from sqlalchemy.testing.suite.test_reflection import (
     ComponentReflectionTest as _ComponentReflectionTest,
 )
@@ -689,4 +692,10 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
     @pytest.mark.skip("Spanner doesn't support temporary tables")
     def test_get_temp_table_unique_constraints(self):
+        pass
+
+
+class InsertBehaviorTest(_InsertBehaviorTest):
+    @pytest.mark.skip("Spanner doesn't support empty inserts")
+    def test_empty_insert(self):
         pass

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -682,3 +682,11 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
         with pytest.raises(spanner_dbapi.exceptions.ProgrammingError):
             self.metadata.create_all()
+
+    @pytest.mark.skip("Spanner doesn't support temporary tables")
+    def test_get_temp_table_indexes(self):
+        pass
+
+    @pytest.mark.skip("Spanner doesn't support temporary tables")
+    def test_get_temp_table_unique_constraints(self):
+        pass


### PR DESCRIPTION
Spanner doesn't support temporary tables. The same tests (for indexes, table names, etc.) are passing on real tables, so these tests can be skipped.