### PR TITLE
test: erase excess installation commands

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -109,10 +109,6 @@ def lint_setup_py(session):
 def compliance_test(session):
     """Run SQLAlchemy dialect compliance test suite."""
     session.install("pytest")
-    session.install("sqlalchemy")
-    session.install(
-        "git+https://github.com/googleapis/python-spanner.git#egg=google-cloud-spanner"
-    )
     session.install("-e", ".")
     session.run("python", "create_test_database.py")
     session.run("pytest", "-v")
@@ -126,8 +122,6 @@ def migration_test(session):
     import shutil
 
     session.install("pytest")
-    session.install("sqlalchemy")
-    session.install("google-cloud-spanner")
     session.install("-e", ".")
     session.install("alembic")
     session.run("alembic", "init", "test_migration")


### PR DESCRIPTION
We talked about it some time ago - there is no need in explicit `sqlalchemy` and `google-cloud-spanner` installations, as `session.install("-e", ".")` will do the job.