### PR TITLE
feat: support interleaved tables feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,33 @@ A migration script can produce a lot of DDL statements. In case of executing eve
 
 Features and limitations
 -----------
+**Interleaved tables**  
+Cloud Spanner dialect includes two dialect-specific arguments for `Table` constructor, which help to define interleave relations:
+`spanner_interleave_in` - a parent table name
+`spanner_inverleave_on_delete_cascade` - a flag specifying if `ON DELETE CASCADE` statement must be used for the interleave relation  
+An example of interleave relations definition:
+```python
+team = Table(
+    "team",
+    metadata,
+    Column("team_id", Integer, primary_key=True),
+    Column("team_name", String(16), nullable=False),
+)
+team.create(engine)
+
+client = Table(
+    "client",
+    metadata,
+    Column("team_id", Integer, primary_key=True),
+    Column("client_id", Integer, primary_key=True),
+    Column("client_name", String(16), nullable=False),
+    spanner_interleave_in="team",
+    spanner_interleave_on_delete_cascade=True,
+)
+
+client.create(engine)
+```
+
 **Unique constraints**  
 Cloud Spanner doesn't support direct UNIQUE constraints creation. In order to achieve column values uniqueness UNIQUE indexes should be used.
 

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -270,8 +270,13 @@ class SpannerDDLCompiler(DDLCompiler):
             str: primary key difinition to add to the table CREATE request.
         """
         cols = [col.name for col in table.primary_key.columns]
+        post_cmds = " PRIMARY KEY ({})".format(", ".join(cols))
 
-        return " PRIMARY KEY ({})".format(", ".join(cols))
+        if table.kwargs.get("spanner_interleave_in"):
+            post_cmds += ",\nINTERLEAVE IN PARENT {} ON DELETE CASCADE".format(
+                table.kwargs["spanner_interleave_in"]
+            )
+        return post_cmds
 
 
 class SpannerTypeCompiler(GenericTypeCompiler):

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -287,8 +287,7 @@ class SpannerDDLCompiler(DDLCompiler):
     def post_create_table(self, table):
         """Build statements to be executed after CREATE TABLE.
 
-        Includes "primary key" and "interleaved
-        table" statements generation.
+        Includes "primary key" and "interleaved table" statements generation.
 
         Args:
             table (sqlalchemy.schema.Table): Table to create.

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -263,6 +263,9 @@ class SpannerDDLCompiler(DDLCompiler):
     def post_create_table(self, table):
         """Build statements to be executed after CREATE TABLE.
 
+        Includes "primary key" and "interleaved
+        table" statements generation.
+
         Args:
             table (sqlalchemy.schema.Table): Table to create.
 
@@ -273,9 +276,13 @@ class SpannerDDLCompiler(DDLCompiler):
         post_cmds = " PRIMARY KEY ({})".format(", ".join(cols))
 
         if table.kwargs.get("spanner_interleave_in"):
-            post_cmds += ",\nINTERLEAVE IN PARENT {} ON DELETE CASCADE".format(
+            post_cmds += ",\nINTERLEAVE IN PARENT {}".format(
                 table.kwargs["spanner_interleave_in"]
             )
+
+            if table.kwargs.get("spanner_inverleave_on_delete_cascade"):
+                post_cmds += " ON DELETE CASCADE"
+
         return post_cmds
 
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1441,8 +1441,8 @@ class TestQueryHints(fixtures.TablesTest):
 
 class InterleavedTablesTest(fixtures.TestBase):
     """
-    Check that CREATE TABLE statements for
-    interleaved tables are correctly generated.
+    Check that CREATE TABLE statements for interleaved tables are correctly
+    generated.
     """
 
     def setUp(self):

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -18,8 +18,10 @@ import operator
 import pytest
 import decimal
 import pytz
+from unittest import mock
 
 import sqlalchemy
+from sqlalchemy import create_engine
 from sqlalchemy import inspect
 from sqlalchemy import testing
 from sqlalchemy import ForeignKey
@@ -1210,3 +1212,58 @@ class CompoundSelectTest(_CompoundSelectTest):
     )
     def test_order_by_selectable_in_unions(self):
         pass
+
+
+class InterleavedTablesTest(fixtures.TestBase):
+    """
+    Check that CREATE TABLE statements for
+    interleaved tables are correctly generated.
+    """
+
+    def setUp(self):
+        self._engine = create_engine(
+            "spanner:///projects/appdev-soda-spanner-staging/instances/"
+            "sqlalchemy-dialect-test/databases/compliance-test"
+        )
+        self._metadata = MetaData(bind=self._engine)
+
+    def test_interleave(self):
+        EXP_QUERY = (
+            "\nCREATE TABLE client (\n\tteam_id INT64 NOT NULL, "
+            "\n\tclient_id INT64 NOT NULL, "
+            "\n\tclient_name STRING(16) NOT NULL"
+            "\n) PRIMARY KEY (team_id, client_id),"
+            "\nINTERLEAVE IN PARENT team\n\n"
+        )
+        client = Table(
+            "client",
+            self._metadata,
+            Column("team_id", Integer, primary_key=True),
+            Column("client_id", Integer, primary_key=True),
+            Column("client_name", String(16), nullable=False),
+            spanner_interleave_in="team",
+        )
+        with mock.patch("google.cloud.spanner_dbapi.cursor.Cursor.execute") as execute:
+            client.create(self._engine)
+            execute.assert_called_once_with(EXP_QUERY, [])
+
+    def test_interleave_on_delete_cascade(self):
+        EXP_QUERY = (
+            "\nCREATE TABLE client (\n\tteam_id INT64 NOT NULL, "
+            "\n\tclient_id INT64 NOT NULL, "
+            "\n\tclient_name STRING(16) NOT NULL"
+            "\n) PRIMARY KEY (team_id, client_id),"
+            "\nINTERLEAVE IN PARENT team ON DELETE CASCADE\n\n"
+        )
+        client = Table(
+            "client",
+            self._metadata,
+            Column("team_id", Integer, primary_key=True),
+            Column("client_id", Integer, primary_key=True),
+            Column("client_name", String(16), nullable=False),
+            spanner_interleave_in="team",
+            spanner_inverleave_on_delete_cascade=True,
+        )
+        with mock.patch("google.cloud.spanner_dbapi.cursor.Cursor.execute") as execute:
+            client.create(self._engine)
+            execute.assert_called_once_with(EXP_QUERY, [])


### PR DESCRIPTION
Adding two dialect-specific arguments:
`spanner_interleave_in` - a name of a parent table
`spanner_inverleave_on_delete_cascade` - a flag indicating if `ON DELETE CASCADE` statement should be added for this inverleave relation